### PR TITLE
PropTypes の利用をやめる

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "node-sass": "^4.11.0",
     "parcel-bundler": "^1.9.4",
     "prismjs": "^1.22.0",
-    "prop-types": "^15.6.0",
     "react": "^16.14.0",
     "react-dom": "^16.8.4",
     "react-helmet": "^5.2.0",

--- a/src/cms/preview-templates/ArticlePreview.tsx
+++ b/src/cms/preview-templates/ArticlePreview.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { BlogPostTemplate } from '../../templates/blog-post';
 import moment from 'moment';
 
@@ -34,13 +33,6 @@ const ArticlePreview = ({
       featuredimage={entry.getIn(['data', 'featuredimage'])}
     />
   );
-};
-
-ArticlePreview.propTypes = {
-  entry: PropTypes.shape({
-    getIn: PropTypes.func,
-  }),
-  widgetFor: PropTypes.func,
 };
 
 export default ArticlePreview;

--- a/src/components/BlogRoll.tsx
+++ b/src/components/BlogRoll.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { Link, graphql, StaticQuery } from 'gatsby';
 import PreviewCompatibleImage from './PreviewCompatibleImage';
 
 class BlogRoll extends React.Component {
+
   render() {
     const { data } = this.props;
     const { edges: posts } = data.allMarkdownRemark;
@@ -74,13 +74,6 @@ class BlogRoll extends React.Component {
   }
 }
 
-BlogRoll.propTypes = {
-  data: PropTypes.shape({
-    allMarkdownRemark: PropTypes.shape({
-      edges: PropTypes.array,
-    }),
-  }),
-};
 
 export default () => (
   <StaticQuery

--- a/src/components/PreviewCompatibleImage.tsx
+++ b/src/components/PreviewCompatibleImage.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import Img from 'gatsby-image';
 
 interface imageInfoType {
@@ -47,18 +46,6 @@ const PreviewCompatibleImage = ({
     return <img style={imageStyle} src={image} alt={alt} />;
 
   return null;
-};
-
-PreviewCompatibleImage.propTypes = {
-  imageInfo: PropTypes.shape({
-    alt: PropTypes.string,
-    childImageSharp: PropTypes.object,
-    image: PropTypes.oneOfType([
-      PropTypes.object,
-      PropTypes.string,
-    ]).isRequired,
-    style: PropTypes.object,
-  }).isRequired,
 };
 
 export default PreviewCompatibleImage;

--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
 import useSiteMetadata from './SiteMetadata';
 import { withPrefix } from 'gatsby';
@@ -75,13 +74,6 @@ const SEO = ({ title, description, image }) => {
 };
 
 export default SEO;
-
-SEO.propTypes = {
-  title: PropTypes.string,
-  description: PropTypes.string,
-  image: PropTypes.string,
-  article: PropTypes.bool,
-};
 
 SEO.defaultProps = {
   title: null,

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { kebabCase } from 'lodash';
 import Helmet from 'react-helmet';
 import { graphql, Link } from 'gatsby';
@@ -116,15 +115,6 @@ export const BlogPostTemplate = ({
   );
 };
 
-BlogPostTemplate.propTypes = {
-  content: PropTypes.node.isRequired,
-  contentComponent: PropTypes.func,
-  title: PropTypes.string,
-  issuedAt: PropTypes.string,
-  helmet: PropTypes.object,
-  featuredimage: PropTypes.object,
-};
-
 const BlogPost = ({ data }) => {
   const { markdownRemark: post, related: related } = data;
 
@@ -156,13 +146,6 @@ const BlogPost = ({ data }) => {
       <RelatedArticles posts={related.edges} />
     </Layout>
   );
-};
-
-BlogPost.propTypes = {
-  data: PropTypes.shape({
-    markdownRemark: PropTypes.object,
-    related: PropTypes.object,
-  }),
 };
 
 export default BlogPost;

--- a/src/templates/index-page.tsx
+++ b/src/templates/index-page.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { Link, graphql } from 'gatsby';
 import PreviewCompatibleImage from '../components/PreviewCompatibleImage';
 
@@ -183,17 +182,6 @@ export const IndexPageTemplate = ({ posts }) => (
   </div>
 );
 
-IndexPageTemplate.propTypes = {
-  image: PropTypes.oneOfType([
-    PropTypes.object,
-    PropTypes.string,
-  ]),
-  title: PropTypes.string,
-  subheading: PropTypes.string,
-  link: PropTypes.string,
-  featuredTags: PropTypes.array,
-};
-
 const IndexPage = ({ data }) => {
   const posts = data.allMarkdownRemark;
 
@@ -205,13 +193,6 @@ const IndexPage = ({ data }) => {
   );
 };
 
-IndexPage.propTypes = {
-  data: PropTypes.shape({
-    markdownRemark: PropTypes.shape({
-      frontmatter: PropTypes.object,
-    }),
-  }),
-};
 
 export default IndexPage;
 


### PR DESCRIPTION
## 目的
PropTypes の利用をやめます。

## PropTypes とは

>PropTypes は受け取ったデータが有効かどうかを確認するために使用できる種々のバリデーターをエクスポートしています。上記の例では、PropTypes.string を使用しています。無効な値がプロパティに与えられた場合、JavaScript のコンソールに警告文が出力されます。(FYI https://ja.reactjs.org/docs/typechecking-with-proptypes.html)

要はpropsで渡ってくる値の型を規定してバリデーションするというやつ。

## なんでPropTypesを消すか
いくつか理由があります。
- typescript なので、本来的には props に型定義を与えれば PropTypes でバリデーションする必要がない
- 本格的に型定義を導入したいが、proptypes 周りを修正するのが怠い
- そもそもブログサイトなので予期せぬ型のデータが入ってくるとかなさそう(apiとかないし)

