### PR TITLE
yarn add sharp　した

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "react-dom": "^16.8.4",
     "react-helmet": "^5.2.0",
     "react-share": "^4.3.1",
+    "sharp": "^0.26.3",
     "styled-components": "^5.2.1",
     "styled-reset": "^4.3.1",
     "typescript": "^4.1.2",


### PR DESCRIPTION
# 目的
sharp とかいうライブラリをpackage.jsonに登録してバージョンを明示的に指定してインストールするようにします。
画像のリサイズに使われるライブラリです(ref: https://www.npmjs.com/package/sharp)

yarn.lock を見ると元々 sharp は何らかの依存関係で利用されている。
なので、今回は package.json でバージョンを指定しただけになります。

```yarn.lock
sharp@^0.26.3:
  version "0.26.3"
  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.26.3.tgz#9de8577a986b22538e6e12ced1f7e8a53f9728de"
  integrity sha512-NdEJ9S6AMr8Px0zgtFo1TJjMK/ROMU92MkDtYn2BBrDjIx3YfH9TUyGdzPC+I/L619GeYQc690Vbaxc5FPCCWg==
  dependencies:
    array-flatten "^3.0.0"
    color "^3.1.3"
    detect-libc "^1.0.3"
    node-addon-api "^3.0.2"
```



# 理由
- typescript対応をしているブランチで yarn start したら sharp がないって怒られる
- 